### PR TITLE
QD-8148 Relax dependencies pinning for `debian` containers

### DIFF
--- a/2023.3/android-community/Dockerfile
+++ b/2023.3/android-community/Dockerfile
@@ -1,23 +1,6 @@
 ARG BASE_TAG="bullseye-slim"
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -33,14 +16,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-         ca-certificates=$CA_CERTIFICATES_VERSION \
-         curl=$CURL_VERSION \
-         fontconfig=$FONTCONFIG_VERSION \
-         git=$GIT_VERSION \
-         git-lfs=$GIT_LFS_VERSION \
-         gnupg2=$GNUPG2_VERSION \
-         locales=$LOCALES_VERSION \
-         procps=$PROCPS_VERSION && \
+         ca-certificates \
+         curl \
+         fontconfig \
+         git \
+         git-lfs \
+         gnupg2 \
+         locales \
+         procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/base/cdnet.Dockerfile
+++ b/2023.3/base/cdnet.Dockerfile
@@ -1,19 +1,6 @@
 ARG DOTNET_BASE_TAG="6.0-bullseye-slim"
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.11-72"
-
 ENV QODANA_DATA="/data" \
     QODANA_DOCKER="true" \
     PATH="/opt/qodana:${PATH}"
@@ -32,12 +19,12 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana /data/project /data/cache /data/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 && \
     apt-get autoremove -y && apt-get clean && \
     curl -fsSL -o /tmp/dotnet-install.sh  \
          "https://raw.githubusercontent.com/dotnet/install-scripts/$DOTNET_INSTALL_SH_REVISION/src/dotnet-install.sh" && \

--- a/2023.3/base/debian.Dockerfile
+++ b/2023.3/base/debian.Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/base/dotnet.Dockerfile
+++ b/2023.3/base/dotnet.Dockerfile
@@ -3,24 +3,6 @@ ARG DOTNET_BASE_TAG="6.0-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_COMMON_VERSION="0.96.20.2-2.1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -49,15 +31,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p $QODANA_DATA $QODANA_CONF $DOTNET_ROOT $RIDER_UNREAL_ROOT && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_COMMON_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/base/go.Dockerfile
+++ b/2023.3/base/go.Dockerfile
@@ -3,22 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM golang:$GO_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -41,14 +25,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/base/js.Dockerfile
+++ b/2023.3/base/js.Dockerfile
@@ -1,22 +1,6 @@
 ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -37,14 +21,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/base/php.Dockerfile
+++ b/2023.3/base/php.Dockerfile
@@ -5,24 +5,6 @@ FROM node:$NODE_TAG AS node_base
 FROM composer:$COMPOSER_TAG AS composer_base
 FROM php:$PHP_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_VERSION="0.96.20.2-2.1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -43,15 +25,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/base/python.Dockerfile
+++ b/2023.3/base/python.Dockerfile
@@ -1,32 +1,5 @@
 FROM debianbase
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
-
 ENV CONDA_DIR="/opt/miniconda3" \
     CONDA_ENVS_PATH="$QODANA_DATA/cache/conda/envs" \
     PIP_CACHE_DIR="$QODANA_DATA/cache/.pip/" \
@@ -42,11 +15,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/2023.3/dotnet-community/Dockerfile
+++ b/2023.3/dotnet-community/Dockerfile
@@ -1,19 +1,6 @@
 ARG DOTNET_BASE_TAG="6.0-bullseye-slim"
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.11-72"
-
 ENV QODANA_DATA="/data" \
     QODANA_DOCKER="true" \
     PATH="/opt/qodana:${PATH}"
@@ -32,12 +19,12 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana /data/project /data/cache /data/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 && \
     apt-get autoremove -y && apt-get clean && \
     curl -fsSL -o /tmp/dotnet-install.sh  \
          "https://raw.githubusercontent.com/dotnet/install-scripts/$DOTNET_INSTALL_SH_REVISION/src/dotnet-install.sh" && \

--- a/2023.3/dotnet/Dockerfile
+++ b/2023.3/dotnet/Dockerfile
@@ -3,24 +3,6 @@ ARG DOTNET_BASE_TAG="6.0-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_COMMON_VERSION="0.96.20.2-2.1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -49,15 +31,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p $QODANA_DATA $QODANA_CONF $DOTNET_ROOT $RIDER_UNREAL_ROOT && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_COMMON_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/go/Dockerfile
+++ b/2023.3/go/Dockerfile
@@ -3,22 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM golang:$GO_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -41,14 +25,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/js/Dockerfile
+++ b/2023.3/js/Dockerfile
@@ -1,22 +1,6 @@
 ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -37,14 +21,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/jvm-community/Dockerfile
+++ b/2023.3/jvm-community/Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/jvm/Dockerfile
+++ b/2023.3/jvm/Dockerfile
@@ -3,22 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -39,14 +23,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/php/Dockerfile
+++ b/2023.3/php/Dockerfile
@@ -5,24 +5,6 @@ FROM node:$NODE_TAG AS node_base
 FROM composer:$COMPOSER_TAG AS composer_base
 FROM php:$PHP_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_VERSION="0.96.20.2-2.1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -43,15 +25,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2023.3/python-community/Dockerfile
+++ b/2023.3/python-community/Dockerfile
@@ -3,33 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -45,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \
@@ -74,11 +47,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/2023.3/python/Dockerfile
+++ b/2023.3/python/Dockerfile
@@ -3,32 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.56.0"
 # renovate: datasource=npm depName=pnpm
@@ -49,14 +23,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \
@@ -78,11 +52,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/2024.1/android-community/Dockerfile
+++ b/2024.1/android-community/Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/android/Dockerfile
+++ b/2024.1/android/Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/base/cdnet.Dockerfile
+++ b/2024.1/base/cdnet.Dockerfile
@@ -1,19 +1,6 @@
 ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.11-72"
-
 ENV QODANA_DATA="/data" \
     QODANA_DOCKER="true" \
     PATH="/opt/qodana:${PATH}"
@@ -32,12 +19,12 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana /data/project /data/cache /data/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 && \
     apt-get autoremove -y && apt-get clean && \
     curl -fsSL -o /tmp/dotnet-install.sh  \
          "https://raw.githubusercontent.com/dotnet/install-scripts/$DOTNET_INSTALL_SH_REVISION/src/dotnet-install.sh" && \

--- a/2024.1/base/cpp.Dockerfile
+++ b/2024.1/base/cpp.Dockerfile
@@ -1,36 +1,6 @@
 ARG BASE_TAG="bookworm-slim"
 FROM debian:$BASE_TAG
 ARG CLANG="16"
-# renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20230311"
-# renovate: datasource=repology depName=debian_12/curl versioning=loose
-ENV CURL_VERSION="7.88.1-10+deb12u6"
-# renovate: datasource=repology depName=debian_12/git versioning=loose
-ENV GIT_VERSION="1:2.39.2-1.1"
-# renovate: datasource=repology depName=debian_12/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="3.3.0-1+b5"
-# renovate: datasource=repology depName=debian_12/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.40-1.1"
-# renovate: datasource=repology depName=debian_12/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.17-74"
-# renovate: datasource=repology depName=debian_12/apt-transport-https versioning=loose
-ENV APT_TRANSPORT_HTTPS_VERSION="2.6.1"
-# renovate: datasource=repology depName=debian_12/autoconf versioning=loose
-ENV AUTOCONF_VERSION="2.71-3"
-# renovate: datasource=repology depName=debian_12/automake versioning=loose
-ENV AUTOMAKE_VERSION="1:1.16.5-1.3"
-# renovate: datasource=repology depName=debian_12/cmake versioning=loose
-ENV CMAKE_VERSION="3.25.1-1"
-# renovate: datasource=repology depName=debian_12/dpkg-dev versioning=loose
-ENV DPKG_DEV_VERSION="1.21.22"
-# renovate: datasource=repology depName=debian_12/file versioning=loose
-ENV FILE_VERSION="1:5.44-3"
-# renovate: datasource=repology depName=debian_12/make versioning=loose
-ENV MAKE_VERSION="4.3-4.1"
-# renovate: datasource=repology depName=debian_12/patch versioning=loose
-ENV PATCH_VERSION="2.7.6-7"
-# renovate: datasource=repology depName=debian_12/libc6-dev versioning=loose
-ENV LIBC6_DEV_VERSION="2.36-9+deb12u7"
 
 ENV QODANA_DATA="/data" \
     QODANA_DOCKER="true"
@@ -46,21 +16,21 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana $QODANA_DATA/project $QODANA_DATA/cache $QODANA_DATA/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        apt-transport-https=$APT_TRANSPORT_HTTPS_VERSION \
-        autoconf=$AUTOCONF_VERSION \
-        automake=$AUTOMAKE_VERSION \
-        cmake=$CMAKE_VERSION \
-        dpkg-dev=$DPKG_DEV_VERSION \
-        file=$FILE_VERSION \
-        make=$MAKE_VERSION \
-        patch=$PATCH_VERSION \
-        libc6-dev=$LIBC6_DEV_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        apt-transport-https \
+        autoconf \
+        automake \
+        cmake \
+        dpkg-dev \
+        file \
+        make \
+        patch \
+        libc6-dev && \
     apt-get autoremove -y && apt-get clean
 
 RUN echo "deb https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${CLANG} main" > /etc/apt/sources.list.d/llvm.list && \

--- a/2024.1/base/debian.Dockerfile
+++ b/2024.1/base/debian.Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/base/dotnet.Dockerfile
+++ b/2024.1/base/dotnet.Dockerfile
@@ -3,24 +3,6 @@ ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_COMMON_VERSION="0.96.20.2-2.1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -49,15 +31,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p $QODANA_DATA $QODANA_CONF $DOTNET_ROOT $RIDER_UNREAL_ROOT && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_COMMON_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/base/go.Dockerfile
+++ b/2024.1/base/go.Dockerfile
@@ -3,22 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM golang:$GO_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -41,14 +25,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/base/js.Dockerfile
+++ b/2024.1/base/js.Dockerfile
@@ -1,22 +1,6 @@
 ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -37,14 +21,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/base/php.Dockerfile
+++ b/2024.1/base/php.Dockerfile
@@ -5,28 +5,6 @@ FROM node:$NODE_TAG AS node_base
 FROM composer:$COMPOSER_TAG AS composer_base
 FROM php:$PHP_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_VERSION="0.96.20.2-2.1"
-# renovate: datasource=repology depName=debian_11/zip versioning=loose
-ENV ZIP_VERSION="3.0-12"
-# renovate: datasource=repology depName=debian_11/unzip versioning=loose
-ENV UNZIP_VERSION="6.0-26+deb11u1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -47,17 +25,17 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_VERSION \
-        zip=$ZIP_VERSION \
-        unzip=$UNZIP_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common \
+        zip \
+        unzip && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/base/python.Dockerfile
+++ b/2024.1/base/python.Dockerfile
@@ -1,32 +1,5 @@
 FROM debianbase
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
-
 ENV CONDA_DIR="/opt/miniconda3" \
     CONDA_ENVS_PATH="$QODANA_DATA/cache/conda/envs" \
     PIP_CACHE_DIR="$QODANA_DATA/cache/.pip/" \
@@ -42,11 +15,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/2024.1/base/ruby.Dockerfile
+++ b/2024.1/base/ruby.Dockerfile
@@ -4,22 +4,6 @@ ARG RUBY_TAG="3.3-slim-bullseye"
 FROM node:$NODE_TAG AS node_base
 FROM ruby:$RUBY_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -40,14 +24,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/base/rust.Dockerfile
+++ b/2024.1/base/rust.Dockerfile
@@ -1,24 +1,6 @@
 ARG RUST_TAG="1.77-slim-bullseye"
 FROM rust:$RUST_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/pkg-config versioning=loose
-ENV PKGCONFIG_VERSION="0.29.2-1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -39,15 +21,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        pkg-config=$PKGCONFIG_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        pkg-config \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/cpp/Dockerfile
+++ b/2024.1/cpp/Dockerfile
@@ -2,37 +2,6 @@ ARG BASE_TAG="bookworm-slim"
 FROM debian:$BASE_TAG
 ARG CLANG="16"
 
-# renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20230311"
-# renovate: datasource=repology depName=debian_12/curl versioning=loose
-ENV CURL_VERSION="7.88.1-10+deb12u6"
-# renovate: datasource=repology depName=debian_12/git versioning=loose
-ENV GIT_VERSION="1:2.39.2-1.1"
-# renovate: datasource=repology depName=debian_12/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="3.3.0-1+b5"
-# renovate: datasource=repology depName=debian_12/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.40-1.1"
-# renovate: datasource=repology depName=debian_12/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.17-74"
-# renovate: datasource=repology depName=debian_12/apt-transport-https versioning=loose
-ENV APT_TRANSPORT_HTTPS_VERSION="2.6.1"
-# renovate: datasource=repology depName=debian_12/autoconf versioning=loose
-ENV AUTOCONF_VERSION="2.71-3"
-# renovate: datasource=repology depName=debian_12/automake versioning=loose
-ENV AUTOMAKE_VERSION="1:1.16.5-1.3"
-# renovate: datasource=repology depName=debian_12/cmake versioning=loose
-ENV CMAKE_VERSION="3.25.1-1"
-# renovate: datasource=repology depName=debian_12/dpkg-dev versioning=loose
-ENV DPKG_DEV_VERSION="1.21.22"
-# renovate: datasource=repology depName=debian_12/file versioning=loose
-ENV FILE_VERSION="1:5.44-3"
-# renovate: datasource=repology depName=debian_12/make versioning=loose
-ENV MAKE_VERSION="4.3-4.1"
-# renovate: datasource=repology depName=debian_12/patch versioning=loose
-ENV PATCH_VERSION="2.7.6-7"
-# renovate: datasource=repology depName=debian_12/libc6-dev versioning=loose
-ENV LIBC6_DEV_VERSION="2.36-9+deb12u7"
-
 ENV QODANA_DATA="/data" \
     QODANA_DOCKER="true"
 ENV PATH="/opt/qodana:${PATH}"
@@ -47,21 +16,21 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana $QODANA_DATA/project $QODANA_DATA/cache $QODANA_DATA/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        apt-transport-https=$APT_TRANSPORT_HTTPS_VERSION \
-        autoconf=$AUTOCONF_VERSION \
-        automake=$AUTOMAKE_VERSION \
-        cmake=$CMAKE_VERSION \
-        dpkg-dev=$DPKG_DEV_VERSION \
-        file=$FILE_VERSION \
-        make=$MAKE_VERSION \
-        patch=$PATCH_VERSION \
-        libc6-dev=$LIBC6_DEV_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        apt-transport-https \
+        autoconf \
+        automake \
+        cmake \
+        dpkg-dev \
+        file \
+        make \
+        patch \
+        libc6-dev && \
     apt-get autoremove -y && apt-get clean
 
 RUN echo "deb https://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-$CLANG main" > /etc/apt/sources.list.d/llvm.list && \

--- a/2024.1/dotnet-community/Dockerfile
+++ b/2024.1/dotnet-community/Dockerfile
@@ -1,19 +1,6 @@
 ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.11-72"
-
 ENV QODANA_DATA="/data" \
     QODANA_DOCKER="true" \
     PATH="/opt/qodana:${PATH}"
@@ -32,12 +19,12 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana /data/project /data/cache /data/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 && \
     apt-get autoremove -y && apt-get clean && \
     curl -fsSL -o /tmp/dotnet-install.sh  \
          "https://raw.githubusercontent.com/dotnet/install-scripts/$DOTNET_INSTALL_SH_REVISION/src/dotnet-install.sh" && \

--- a/2024.1/dotnet/Dockerfile
+++ b/2024.1/dotnet/Dockerfile
@@ -3,24 +3,6 @@ ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_COMMON_VERSION="0.96.20.2-2.1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -49,15 +31,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p $QODANA_DATA $QODANA_CONF $DOTNET_ROOT $RIDER_UNREAL_ROOT && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_COMMON_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/go/Dockerfile
+++ b/2024.1/go/Dockerfile
@@ -3,22 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM golang:$GO_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -41,14 +25,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/js/Dockerfile
+++ b/2024.1/js/Dockerfile
@@ -1,22 +1,6 @@
 ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -37,14 +21,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/jvm-community/Dockerfile
+++ b/2024.1/jvm-community/Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/jvm/Dockerfile
+++ b/2024.1/jvm/Dockerfile
@@ -3,22 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -39,14 +23,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/php/Dockerfile
+++ b/2024.1/php/Dockerfile
@@ -5,28 +5,6 @@ FROM node:$NODE_TAG AS node_base
 FROM composer:$COMPOSER_TAG AS composer_base
 FROM php:$PHP_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_VERSION="0.96.20.2-2.1"
-# renovate: datasource=repology depName=debian_11/zip versioning=loose
-ENV ZIP_VERSION="3.0-12"
-# renovate: datasource=repology depName=debian_11/unzip versioning=loose
-ENV UNZIP_VERSION="6.0-26+deb11u1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -47,17 +25,17 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_VERSION \
-        zip=$ZIP_VERSION \
-        unzip=$UNZIP_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common \
+        zip \
+        unzip && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.1/python-community/Dockerfile
+++ b/2024.1/python-community/Dockerfile
@@ -3,33 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -45,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \
@@ -74,11 +47,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/2024.1/python/Dockerfile
+++ b/2024.1/python/Dockerfile
@@ -3,32 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u12"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u2"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="8.57.0"
 # renovate: datasource=npm depName=pnpm
@@ -49,14 +23,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \
@@ -78,11 +52,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/2024.2/android-community/Dockerfile
+++ b/2024.2/android-community/Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/android/Dockerfile
+++ b/2024.2/android/Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/base/cdnet.Dockerfile
+++ b/2024.2/base/cdnet.Dockerfile
@@ -1,21 +1,6 @@
 ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.11-72"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DATA="/data" \
@@ -36,13 +21,13 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana /data/project /data/cache /data/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     curl -fsSL -o /tmp/dotnet-install.sh  \

--- a/2024.2/base/cnova.Dockerfile
+++ b/2024.2/base/cnova.Dockerfile
@@ -4,36 +4,6 @@ FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
 ARG CLANG="16"
-# renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20230311"
-# renovate: datasource=repology depName=debian_12/curl versioning=loose
-ENV CURL_VERSION="7.88.1-10+deb12u7"
-# renovate: datasource=repology depName=debian_12/git versioning=loose
-ENV GIT_VERSION="1:2.39.5-0+deb12u1"
-# renovate: datasource=repology depName=debian_12/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="3.3.0-1+b5"
-# renovate: datasource=repology depName=debian_12/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.40-1.1"
-# renovate: datasource=repology depName=debian_12/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.17-74"
-# renovate: datasource=repology depName=debian_12/apt-transport-https versioning=loose
-ENV APT_TRANSPORT_HTTPS_VERSION="2.6.1"
-# renovate: datasource=repology depName=debian_12/autoconf versioning=loose
-ENV AUTOCONF_VERSION="2.71-3"
-# renovate: datasource=repology depName=debian_12/automake versioning=loose
-ENV AUTOMAKE_VERSION="1:1.16.5-1.3"
-# renovate: datasource=repology depName=debian_12/cmake versioning=loose
-ENV CMAKE_VERSION="3.25.1-1"
-# renovate: datasource=repology depName=debian_12/dpkg-dev versioning=loose
-ENV DPKG_DEV_VERSION="1.21.22"
-# renovate: datasource=repology depName=debian_12/file versioning=loose
-ENV FILE_VERSION="1:5.44-3"
-# renovate: datasource=repology depName=debian_12/make versioning=loose
-ENV MAKE_VERSION="4.3-4.1"
-# renovate: datasource=repology depName=debian_12/patch versioning=loose
-ENV PATCH_VERSION="2.7.6-7"
-# renovate: datasource=repology depName=debian_12/libc6-dev versioning=loose
-ENV LIBC6_DEV_VERSION="2.36-9+deb12u8"
 
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
@@ -59,22 +29,22 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana $QODANA_DATA/project $QODANA_DATA/cache $QODANA_DATA/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        apt-transport-https=$APT_TRANSPORT_HTTPS_VERSION \
-        autoconf=$AUTOCONF_VERSION \
-        automake=$AUTOMAKE_VERSION \
-        cmake=$CMAKE_VERSION \
-        dpkg-dev=$DPKG_DEV_VERSION \
-        file=$FILE_VERSION \
-        make=$MAKE_VERSION \
-        patch=$PATCH_VERSION \
-        libc6-dev=$LIBC6_DEV_VERSION \
-        locales=$LIBC6_DEV_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        apt-transport-https \
+        autoconf \
+        automake \
+        cmake \
+        dpkg-dev \
+        file \
+        make \
+        patch \
+        libc6-dev \
+        locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/base/cpp.Dockerfile
+++ b/2024.2/base/cpp.Dockerfile
@@ -1,36 +1,6 @@
 ARG BASE_TAG="bookworm-slim"
 FROM debian:$BASE_TAG
 ARG CLANG="16"
-# renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20230311"
-# renovate: datasource=repology depName=debian_12/curl versioning=loose
-ENV CURL_VERSION="7.88.1-10+deb12u7"
-# renovate: datasource=repology depName=debian_12/git versioning=loose
-ENV GIT_VERSION="1:2.39.5-0+deb12u1"
-# renovate: datasource=repology depName=debian_12/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="3.3.0-1+b5"
-# renovate: datasource=repology depName=debian_12/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.40-1.1"
-# renovate: datasource=repology depName=debian_12/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.17-74"
-# renovate: datasource=repology depName=debian_12/apt-transport-https versioning=loose
-ENV APT_TRANSPORT_HTTPS_VERSION="2.6.1"
-# renovate: datasource=repology depName=debian_12/autoconf versioning=loose
-ENV AUTOCONF_VERSION="2.71-3"
-# renovate: datasource=repology depName=debian_12/automake versioning=loose
-ENV AUTOMAKE_VERSION="1:1.16.5-1.3"
-# renovate: datasource=repology depName=debian_12/cmake versioning=loose
-ENV CMAKE_VERSION="3.25.1-1"
-# renovate: datasource=repology depName=debian_12/dpkg-dev versioning=loose
-ENV DPKG_DEV_VERSION="1.21.22"
-# renovate: datasource=repology depName=debian_12/file versioning=loose
-ENV FILE_VERSION="1:5.44-3"
-# renovate: datasource=repology depName=debian_12/make versioning=loose
-ENV MAKE_VERSION="4.3-4.1"
-# renovate: datasource=repology depName=debian_12/patch versioning=loose
-ENV PATCH_VERSION="2.7.6-7"
-# renovate: datasource=repology depName=debian_12/libc6-dev versioning=loose
-ENV LIBC6_DEV_VERSION="2.36-9+deb12u8"
 
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
@@ -48,22 +18,22 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana $QODANA_DATA/project $QODANA_DATA/cache $QODANA_DATA/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        apt-transport-https=$APT_TRANSPORT_HTTPS_VERSION \
-        autoconf=$AUTOCONF_VERSION \
-        automake=$AUTOMAKE_VERSION \
-        cmake=$CMAKE_VERSION \
-        dpkg-dev=$DPKG_DEV_VERSION \
-        file=$FILE_VERSION \
-        make=$MAKE_VERSION \
-        patch=$PATCH_VERSION \
-        libc6-dev=$LIBC6_DEV_VERSION \
-        locales=$LIBC6_DEV_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        apt-transport-https \
+        autoconf \
+        automake \
+        cmake \
+        dpkg-dev \
+        file \
+        make \
+        patch \
+        libc6-dev \
+        locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/base/debian.Dockerfile
+++ b/2024.2/base/debian.Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/base/dotnet.Dockerfile
+++ b/2024.2/base/dotnet.Dockerfile
@@ -3,24 +3,6 @@ ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_COMMON_VERSION="0.96.20.2-2.1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -49,15 +31,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p $QODANA_DATA $QODANA_CONF $DOTNET_ROOT $RIDER_UNREAL_ROOT && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_COMMON_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/base/go.Dockerfile
+++ b/2024.2/base/go.Dockerfile
@@ -3,22 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM golang:$GO_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -41,14 +25,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/base/js.Dockerfile
+++ b/2024.2/base/js.Dockerfile
@@ -1,22 +1,6 @@
 ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -37,14 +21,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/base/php.Dockerfile
+++ b/2024.2/base/php.Dockerfile
@@ -5,28 +5,6 @@ FROM node:$NODE_TAG AS node_base
 FROM composer:$COMPOSER_TAG AS composer_base
 FROM php:$PHP_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_VERSION="0.96.20.2-2.1"
-# renovate: datasource=repology depName=debian_11/zip versioning=loose
-ENV ZIP_VERSION="3.0-12"
-# renovate: datasource=repology depName=debian_11/unzip versioning=loose
-ENV UNZIP_VERSION="6.0-26+deb11u1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -47,17 +25,17 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_VERSION \
-        zip=$ZIP_VERSION \
-        unzip=$UNZIP_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common \
+        zip \
+        unzip && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/base/python.Dockerfile
+++ b/2024.2/base/python.Dockerfile
@@ -1,32 +1,5 @@
 FROM debianbase
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
-
 ENV CONDA_DIR="/opt/miniconda3" \
     CONDA_ENVS_PATH="$QODANA_DATA/cache/conda/envs" \
     PIP_CACHE_DIR="$QODANA_DATA/cache/.pip/" \
@@ -42,11 +15,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/2024.2/base/ruby.Dockerfile
+++ b/2024.2/base/ruby.Dockerfile
@@ -4,22 +4,6 @@ ARG RUBY_TAG="3.3-slim-bullseye"
 FROM node:$NODE_TAG AS node_base
 FROM ruby:$RUBY_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -40,14 +24,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/base/rust.Dockerfile
+++ b/2024.2/base/rust.Dockerfile
@@ -1,24 +1,6 @@
 ARG RUST_TAG="1.79-slim-bullseye"
 FROM rust:$RUST_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/pkg-config versioning=loose
-ENV PKGCONFIG_VERSION="0.29.2-1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -39,15 +21,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        pkg-config=$PKGCONFIG_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        pkg-config \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/cpp/Dockerfile
+++ b/2024.2/cpp/Dockerfile
@@ -1,36 +1,6 @@
 ARG BASE_TAG="bookworm-slim"
 FROM debian:$BASE_TAG
 ARG CLANG="16"
-# renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20230311"
-# renovate: datasource=repology depName=debian_12/curl versioning=loose
-ENV CURL_VERSION="7.88.1-10+deb12u7"
-# renovate: datasource=repology depName=debian_12/git versioning=loose
-ENV GIT_VERSION="1:2.39.5-0+deb12u1"
-# renovate: datasource=repology depName=debian_12/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="3.3.0-1+b5"
-# renovate: datasource=repology depName=debian_12/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.40-1.1"
-# renovate: datasource=repology depName=debian_12/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.17-74"
-# renovate: datasource=repology depName=debian_12/apt-transport-https versioning=loose
-ENV APT_TRANSPORT_HTTPS_VERSION="2.6.1"
-# renovate: datasource=repology depName=debian_12/autoconf versioning=loose
-ENV AUTOCONF_VERSION="2.71-3"
-# renovate: datasource=repology depName=debian_12/automake versioning=loose
-ENV AUTOMAKE_VERSION="1:1.16.5-1.3"
-# renovate: datasource=repology depName=debian_12/cmake versioning=loose
-ENV CMAKE_VERSION="3.25.1-1"
-# renovate: datasource=repology depName=debian_12/dpkg-dev versioning=loose
-ENV DPKG_DEV_VERSION="1.21.22"
-# renovate: datasource=repology depName=debian_12/file versioning=loose
-ENV FILE_VERSION="1:5.44-3"
-# renovate: datasource=repology depName=debian_12/make versioning=loose
-ENV MAKE_VERSION="4.3-4.1"
-# renovate: datasource=repology depName=debian_12/patch versioning=loose
-ENV PATCH_VERSION="2.7.6-7"
-# renovate: datasource=repology depName=debian_12/libc6-dev versioning=loose
-ENV LIBC6_DEV_VERSION="2.36-9+deb12u8"
 
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
@@ -48,22 +18,22 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana $QODANA_DATA/project $QODANA_DATA/cache $QODANA_DATA/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        apt-transport-https=$APT_TRANSPORT_HTTPS_VERSION \
-        autoconf=$AUTOCONF_VERSION \
-        automake=$AUTOMAKE_VERSION \
-        cmake=$CMAKE_VERSION \
-        dpkg-dev=$DPKG_DEV_VERSION \
-        file=$FILE_VERSION \
-        make=$MAKE_VERSION \
-        patch=$PATCH_VERSION \
-        libc6-dev=$LIBC6_DEV_VERSION \
-        locales=$LIBC6_DEV_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        apt-transport-https \
+        autoconf \
+        automake \
+        cmake \
+        dpkg-dev \
+        file \
+        make \
+        patch \
+        libc6-dev \
+        locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/dotnet-community/Dockerfile
+++ b/2024.2/dotnet-community/Dockerfile
@@ -1,21 +1,6 @@
 ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.11-72"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DATA="/data" \
@@ -36,13 +21,13 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana /data/project /data/cache /data/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     curl -fsSL -o /tmp/dotnet-install.sh  \

--- a/2024.2/dotnet/Dockerfile
+++ b/2024.2/dotnet/Dockerfile
@@ -3,24 +3,6 @@ ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_COMMON_VERSION="0.96.20.2-2.1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -49,15 +31,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p $QODANA_DATA $QODANA_CONF $DOTNET_ROOT $RIDER_UNREAL_ROOT && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_COMMON_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/go/Dockerfile
+++ b/2024.2/go/Dockerfile
@@ -3,22 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM golang:$GO_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -41,14 +25,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/js/Dockerfile
+++ b/2024.2/js/Dockerfile
@@ -1,22 +1,6 @@
 ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -37,14 +21,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/jvm-community/Dockerfile
+++ b/2024.2/jvm-community/Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/jvm/Dockerfile
+++ b/2024.2/jvm/Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/php/Dockerfile
+++ b/2024.2/php/Dockerfile
@@ -5,28 +5,6 @@ FROM node:$NODE_TAG AS node_base
 FROM composer:$COMPOSER_TAG AS composer_base
 FROM php:$PHP_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_VERSION="0.96.20.2-2.1"
-# renovate: datasource=repology depName=debian_11/zip versioning=loose
-ENV ZIP_VERSION="3.0-12"
-# renovate: datasource=repology depName=debian_11/unzip versioning=loose
-ENV UNZIP_VERSION="6.0-26+deb11u1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -47,17 +25,17 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_VERSION \
-        zip=$ZIP_VERSION \
-        unzip=$UNZIP_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common \
+        zip \
+        unzip && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/2024.2/python-community/Dockerfile
+++ b/2024.2/python-community/Dockerfile
@@ -3,33 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -45,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \
@@ -74,11 +47,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/2024.2/python/Dockerfile
+++ b/2024.2/python/Dockerfile
@@ -3,32 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.8.0"
 # renovate: datasource=npm depName=pnpm
@@ -49,14 +23,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \
@@ -78,11 +52,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/next/base/cdnet.Dockerfile
+++ b/next/base/cdnet.Dockerfile
@@ -1,21 +1,6 @@
 ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.11-72"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DATA="/data" \
@@ -36,13 +21,13 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana /data/project /data/cache /data/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     curl -fsSL -o /tmp/dotnet-install.sh  \

--- a/next/base/cnova.Dockerfile
+++ b/next/base/cnova.Dockerfile
@@ -4,36 +4,6 @@ FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
 ARG CLANG="16"
-# renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20230311"
-# renovate: datasource=repology depName=debian_12/curl versioning=loose
-ENV CURL_VERSION="7.88.1-10+deb12u7"
-# renovate: datasource=repology depName=debian_12/git versioning=loose
-ENV GIT_VERSION="1:2.39.5-0+deb12u1"
-# renovate: datasource=repology depName=debian_12/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="3.3.0-1+b5"
-# renovate: datasource=repology depName=debian_12/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.40-1.1"
-# renovate: datasource=repology depName=debian_12/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.17-74"
-# renovate: datasource=repology depName=debian_12/apt-transport-https versioning=loose
-ENV APT_TRANSPORT_HTTPS_VERSION="2.6.1"
-# renovate: datasource=repology depName=debian_12/autoconf versioning=loose
-ENV AUTOCONF_VERSION="2.71-3"
-# renovate: datasource=repology depName=debian_12/automake versioning=loose
-ENV AUTOMAKE_VERSION="1:1.16.5-1.3"
-# renovate: datasource=repology depName=debian_12/cmake versioning=loose
-ENV CMAKE_VERSION="3.25.1-1"
-# renovate: datasource=repology depName=debian_12/dpkg-dev versioning=loose
-ENV DPKG_DEV_VERSION="1.21.22"
-# renovate: datasource=repology depName=debian_12/file versioning=loose
-ENV FILE_VERSION="1:5.44-3"
-# renovate: datasource=repology depName=debian_12/make versioning=loose
-ENV MAKE_VERSION="4.3-4.1"
-# renovate: datasource=repology depName=debian_12/patch versioning=loose
-ENV PATCH_VERSION="2.7.6-7"
-# renovate: datasource=repology depName=debian_12/libc6-dev versioning=loose
-ENV LIBC6_DEV_VERSION="2.36-9+deb12u8"
 
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.11.1"
@@ -59,22 +29,22 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana $QODANA_DATA/project $QODANA_DATA/cache $QODANA_DATA/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        apt-transport-https=$APT_TRANSPORT_HTTPS_VERSION \
-        autoconf=$AUTOCONF_VERSION \
-        automake=$AUTOMAKE_VERSION \
-        cmake=$CMAKE_VERSION \
-        dpkg-dev=$DPKG_DEV_VERSION \
-        file=$FILE_VERSION \
-        make=$MAKE_VERSION \
-        patch=$PATCH_VERSION \
-        libc6-dev=$LIBC6_DEV_VERSION \
-        locales=$LIBC6_DEV_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        apt-transport-https \
+        autoconf \
+        automake \
+        cmake \
+        dpkg-dev \
+        file \
+        make \
+        patch \
+        libc6-dev \
+        locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/next/base/cpp.Dockerfile
+++ b/next/base/cpp.Dockerfile
@@ -1,36 +1,6 @@
 ARG BASE_TAG="bookworm-slim"
 FROM debian:$BASE_TAG
 ARG CLANG="16"
-# renovate: datasource=repology depName=debian_12/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20230311"
-# renovate: datasource=repology depName=debian_12/curl versioning=loose
-ENV CURL_VERSION="7.88.1-10+deb12u7"
-# renovate: datasource=repology depName=debian_12/git versioning=loose
-ENV GIT_VERSION="1:2.39.5-0+deb12u1"
-# renovate: datasource=repology depName=debian_12/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="3.3.0-1+b5"
-# renovate: datasource=repology depName=debian_12/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.40-1.1"
-# renovate: datasource=repology depName=debian_12/default-jre versioning=loose
-ENV DEFAULT_JRE_VERSION="2:1.17-74"
-# renovate: datasource=repology depName=debian_12/apt-transport-https versioning=loose
-ENV APT_TRANSPORT_HTTPS_VERSION="2.6.1"
-# renovate: datasource=repology depName=debian_12/autoconf versioning=loose
-ENV AUTOCONF_VERSION="2.71-3"
-# renovate: datasource=repology depName=debian_12/automake versioning=loose
-ENV AUTOMAKE_VERSION="1:1.16.5-1.3"
-# renovate: datasource=repology depName=debian_12/cmake versioning=loose
-ENV CMAKE_VERSION="3.25.1-1"
-# renovate: datasource=repology depName=debian_12/dpkg-dev versioning=loose
-ENV DPKG_DEV_VERSION="1.21.22"
-# renovate: datasource=repology depName=debian_12/file versioning=loose
-ENV FILE_VERSION="1:5.44-3"
-# renovate: datasource=repology depName=debian_12/make versioning=loose
-ENV MAKE_VERSION="4.3-4.1"
-# renovate: datasource=repology depName=debian_12/patch versioning=loose
-ENV PATCH_VERSION="2.7.6-7"
-# renovate: datasource=repology depName=debian_12/libc6-dev versioning=loose
-ENV LIBC6_DEV_VERSION="2.36-9+deb12u8"
 
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
@@ -48,22 +18,22 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt/qodana $QODANA_DATA/project $QODANA_DATA/cache $QODANA_DATA/results && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        default-jre=$DEFAULT_JRE_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        apt-transport-https=$APT_TRANSPORT_HTTPS_VERSION \
-        autoconf=$AUTOCONF_VERSION \
-        automake=$AUTOMAKE_VERSION \
-        cmake=$CMAKE_VERSION \
-        dpkg-dev=$DPKG_DEV_VERSION \
-        file=$FILE_VERSION \
-        make=$MAKE_VERSION \
-        patch=$PATCH_VERSION \
-        libc6-dev=$LIBC6_DEV_VERSION \
-        locales=$LIBC6_DEV_VERSION && \
+        ca-certificates \
+        curl \
+        default-jre \
+        git \
+        git-lfs \
+        gnupg2 \
+        apt-transport-https \
+        autoconf \
+        automake \
+        cmake \
+        dpkg-dev \
+        file \
+        make \
+        patch \
+        libc6-dev \
+        locales && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/next/base/debian.Dockerfile
+++ b/next/base/debian.Dockerfile
@@ -3,23 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM debian:$BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-
 ENV HOME="/root" \
     LC_ALL="en_US.UTF-8" \
     QODANA_DIST="/opt/idea" \
@@ -35,14 +18,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/next/base/dotnet.Dockerfile
+++ b/next/base/dotnet.Dockerfile
@@ -3,24 +3,6 @@ ARG DOTNET_BASE_TAG="7.0-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNET_BASE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_COMMON_VERSION="0.96.20.2-2.1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.11.1"
 # renovate: datasource=npm depName=pnpm
@@ -49,15 +31,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p $QODANA_DATA $QODANA_CONF $DOTNET_ROOT $RIDER_UNREAL_ROOT && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_COMMON_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/next/base/go.Dockerfile
+++ b/next/base/go.Dockerfile
@@ -3,22 +3,6 @@ ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG AS node_base
 FROM golang:$GO_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.11.1"
 # renovate: datasource=npm depName=pnpm
@@ -41,14 +25,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/next/base/js.Dockerfile
+++ b/next/base/js.Dockerfile
@@ -1,22 +1,6 @@
 ARG NODE_TAG="20-bullseye-slim"
 FROM node:$NODE_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.11.1"
 # renovate: datasource=npm depName=pnpm
@@ -37,14 +21,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/next/base/php.Dockerfile
+++ b/next/base/php.Dockerfile
@@ -5,28 +5,6 @@ FROM node:$NODE_TAG AS node_base
 FROM composer:$COMPOSER_TAG AS composer_base
 FROM php:$PHP_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/software-properties-common versioning=loose
-ENV SOFTWARE_PROPERTIES_VERSION="0.96.20.2-2.1"
-# renovate: datasource=repology depName=debian_11/zip versioning=loose
-ENV ZIP_VERSION="3.0-12"
-# renovate: datasource=repology depName=debian_11/unzip versioning=loose
-ENV UNZIP_VERSION="6.0-26+deb11u1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.11.1"
 # renovate: datasource=npm depName=pnpm
@@ -47,17 +25,17 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION \
-        software-properties-common=$SOFTWARE_PROPERTIES_VERSION \
-        zip=$ZIP_VERSION \
-        unzip=$UNZIP_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps \
+        software-properties-common \
+        zip \
+        unzip && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/next/base/python.Dockerfile
+++ b/next/base/python.Dockerfile
@@ -1,32 +1,5 @@
 FROM debianbase
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/bzip2 versioning=loose
-ENV BZIP2_VERSION="1.0.8-4"
-# renovate: datasource=repology depName=debian_11/libglib2.0-0 versioning=loose
-ENV LIBGLIB2_0_0_VERSION="2.66.8-1+deb11u4"
-# renovate: datasource=repology depName=debian_11/libsm6 versioning=loose
-ENV LIBSM6_VERSION="2:1.2.3-1"
-# renovate: datasource=repology depName=debian_11/libxext6 versioning=loose
-ENV LIBXEXT6_VERSION="2:1.3.3-1.1"
-# renovate: datasource=repology depName=debian_11/libxrender1 versioning=loose
-ENV LIBXRENDER1_VERSION="1:0.9.10-1"
-
 ENV CONDA_DIR="/opt/miniconda3" \
     CONDA_ENVS_PATH="$QODANA_DATA/cache/conda/envs" \
     PIP_CACHE_DIR="$QODANA_DATA/cache/.pip/" \
@@ -42,11 +15,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      bzip2=$BZIP2_VERSION \
-      libglib2.0-0=$LIBGLIB2_0_0_VERSION \
-      libsm6=$LIBSM6_VERSION \
-      libxext6=$LIBXEXT6_VERSION \
-      libxrender1=$LIBXRENDER1_VERSION && \
+      bzip2 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 && \
     mkdir -m 777 -p $QODANA_DATA/cache && \
     dpkgArch="$(dpkg --print-architecture)" && \
     case "$dpkgArch" in \

--- a/next/base/ruby.Dockerfile
+++ b/next/base/ruby.Dockerfile
@@ -4,22 +4,6 @@ ARG RUBY_TAG="3.3-slim-bullseye"
 FROM node:$NODE_TAG AS node_base
 FROM ruby:$RUBY_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.11.1"
 # renovate: datasource=npm depName=pnpm
@@ -40,14 +24,14 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \

--- a/next/base/rust.Dockerfile
+++ b/next/base/rust.Dockerfile
@@ -1,24 +1,6 @@
 ARG RUST_TAG="1.81-slim-bullseye"
 FROM rust:$RUST_TAG
 
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CA_CERTIFICATES_VERSION="20210119"
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION="7.74.0-1.3+deb11u13"
-# renovate: datasource=repology depName=debian_11/fontconfig versioning=loose
-ENV FONTCONFIG_VERSION="2.13.1-4.2"
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION="1:2.30.2-1+deb11u3"
-# renovate: datasource=repology depName=debian_11/git-lfs versioning=loose
-ENV GIT_LFS_VERSION="2.13.2-1+b5"
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG2_VERSION="2.2.27-2+deb11u2"
-# renovate: datasource=repology depName=debian_11/locales versioning=loose
-ENV LOCALES_VERSION="2.31-13+deb11u10"
-# renovate: datasource=repology depName=debian_11/procps versioning=loose
-ENV PROCPS_VERSION="2:3.3.17-5"
-# renovate: datasource=repology depName=debian_11/pkg-config versioning=loose
-ENV PKGCONFIG_VERSION="0.29.2-1"
 # renovate: datasource=npm depName=eslint
 ENV ESLINT_VERSION="9.11.1"
 # renovate: datasource=npm depName=pnpm
@@ -39,15 +21,15 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
     mkdir -m 777 -p /opt $QODANA_DATA $QODANA_CONF && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  \
-        ca-certificates=$CA_CERTIFICATES_VERSION \
-        curl=$CURL_VERSION \
-        fontconfig=$FONTCONFIG_VERSION \
-        git=$GIT_VERSION \
-        git-lfs=$GIT_LFS_VERSION \
-        gnupg2=$GNUPG2_VERSION \
-        locales=$LOCALES_VERSION \
-        pkg-config=$PKGCONFIG_VERSION \
-        procps=$PROCPS_VERSION && \
+        ca-certificates \
+        curl \
+        fontconfig \
+        git \
+        git-lfs \
+        gnupg2 \
+        locales \
+        pkg-config \
+        procps && \
     echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen && \
     apt-get autoremove -y && apt-get clean && \
     chmod 777 -R $HOME && \


### PR DESCRIPTION
## Summary

- Stop pinning versions for packages installed through `apt` from official repositories (so this change only affects `apt` dependencies from the official Debian stable channel)
- Apt usually keeps only one version of a package, and there won't be updates that could break without updating the base image (note: base images are used only internally)

What was actually done:
- Find `(=\$\w+_VERSION)(\s*\\|\s*&&\s*\\)` and replace with `$2`
- Find `\# renovate\: datasource\=repology depName\=debian_.*\nENV .*"` and replace with `$2`
- Find `^\s*\n+` and replace with `\n`