### PR TITLE
QD-10493 Fix `QDAND` JDKs permissions issue

### DIFF
--- a/2024.3/android-community/Dockerfile
+++ b/2024.3/android-community/Dockerfile
@@ -97,7 +97,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     unzip -q /tmp/android.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools && \
     mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/tools && \
     echo y | ${ANDROID_SDK_TOOLS}/sdkmanager "platforms;android-${ANDROID_API_LEVEL}" && \
-    chmod 777 -R $ANDROID_SDK_ROOT && \
+    chmod 777 -R $ANDROID_SDK_ROOT $HOME/.jdks/ && \
     apt-get purge --auto-remove -y unzip && \
     rm -rf /tmp/*
 

--- a/2024.3/android-community/internal.Dockerfile
+++ b/2024.3/android-community/internal.Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     unzip -q /tmp/android.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools && \
     mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/tools && \
     echo y | ${ANDROID_SDK_TOOLS}/sdkmanager "platforms;android-${ANDROID_API_LEVEL}" && \
-    chmod 777 -R $ANDROID_SDK_ROOT && \
+    chmod 777 -R $ANDROID_SDK_ROOT $HOME/.jdks/ && \
     apt-get purge --auto-remove -y unzip && \
     rm -rf /tmp/*
 

--- a/2024.3/android/Dockerfile
+++ b/2024.3/android/Dockerfile
@@ -97,7 +97,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     unzip -q /tmp/android.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools && \
     mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/tools && \
     echo y | ${ANDROID_SDK_TOOLS}/sdkmanager "platforms;android-${ANDROID_API_LEVEL}" && \
-    chmod 777 -R $ANDROID_SDK_ROOT && \
+    chmod 777 -R $ANDROID_SDK_ROOT $HOME/.jdks/ && \
     apt-get purge --auto-remove -y unzip && \
     rm -rf /tmp/*
 

--- a/2024.3/android/internal.Dockerfile
+++ b/2024.3/android/internal.Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     unzip -q /tmp/android.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools && \
     mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/tools && \
     echo y | ${ANDROID_SDK_TOOLS}/sdkmanager "platforms;android-${ANDROID_API_LEVEL}" && \
-    chmod 777 -R $ANDROID_SDK_ROOT && \
+    chmod 777 -R $ANDROID_SDK_ROOT $HOME/.jdks/ && \
     apt-get purge --auto-remove -y unzip && \
     rm -rf /tmp/*
 

--- a/next/android-community/internal.Dockerfile
+++ b/next/android-community/internal.Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     unzip -q /tmp/android.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools && \
     mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/tools && \
     echo y | ${ANDROID_SDK_TOOLS}/sdkmanager "platforms;android-${ANDROID_API_LEVEL}" && \
-    chmod 777 -R $ANDROID_SDK_ROOT && \
+    chmod 777 -R $ANDROID_SDK_ROOT $HOME/.jdks/ && \
     apt-get purge --auto-remove -y unzip && \
     rm -rf /tmp/*
 

--- a/next/android/internal.Dockerfile
+++ b/next/android/internal.Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     unzip -q /tmp/android.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools && \
     mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/tools && \
     echo y | ${ANDROID_SDK_TOOLS}/sdkmanager "platforms;android-${ANDROID_API_LEVEL}" && \
-    chmod 777 -R $ANDROID_SDK_ROOT && \
+    chmod 777 -R $ANDROID_SDK_ROOT $HOME/.jdks/ && \
     apt-get purge --auto-remove -y unzip && \
     rm -rf /tmp/*
 


### PR DESCRIPTION
This pull request includes changes to multiple Dockerfiles across different versions and configurations to ensure that the `chmod` command also applies to the `$HOME/.jdks/` directory. 

**Changes to Dockerfiles:**

* Updated `chmod` command to include `$HOME/.jdks/` directory in the following files:
  * `2023.2/android-community/Dockerfile`
  * `2023.3/android-community/Dockerfile`
  * `2023.3/android-community/internal.Dockerfile`
  * `2024.1/android-community/Dockerfile`
  * `2024.1/android-community/internal.Dockerfile`
  * `2024.1/android/Dockerfile`
  * `2024.1/android/internal.Dockerfile`
  * `2024.2/android-community/Dockerfile`
  * `2024.2/android-community/internal.Dockerfile`
  * `2024.2/android/Dockerfile`
  * `2024.2/android/internal.Dockerfile`
  * `2024.3/android-community/Dockerfile`
  * `2024.3/android-community/internal.Dockerfile`
  * `2024.3/android/Dockerfile`
  * `2024.3/android/internal.Dockerfile`
  * `next/android-community/internal.Dockerfile`
  * `next/android/internal.Dockerfile`

**Why:** we do `chmod ...`, e.g. 

https://github.com/JetBrains/qodana-docker/blob/3e983a6f4de961a149284a47ebe2814d4eeacb78/2024.3/android-community/Dockerfile#L31

but this is not enough because in Android linters we perform operations with `root` user 
https://github.com/JetBrains/qodana-docker/blob/3e983a6f4de961a149284a47ebe2814d4eeacb78/2024.3/android-community/Dockerfile#L81-L82
So `$HOME/.jdks` becomes owned by the root user
```
$ pwd
/root/.jdks
$ ls -la
total 16
drwxr-xr-x 1 root root 4096 Dec  9 05:10 .
drwxrwxrwx 1 root root 4096 Dec  9 16:01 ..
drwxr-xr-x 9 root root 4096 Nov 16 00:47 corretto-11
drwxr-xr-x 9 root root 4096 Nov 16 00:48 corretto-17
```

```
── [drwxrwxrwx]  root
│   ├── [-rwxrwxrwx]  .bashrc
│   ├── [drwxr-xr-x]  .cache
│   │   └── [drwxr-xr-x]  rosetta
│   ├── [drwxrwxrwx]  .config
│   │   └── [drwxrwxrwx]  idea
│   ├── [-rw-r--r--]  .gitconfig
│   ├── [drwxr-xr-x]  .jdks
│   │   ├── [drwxr-xr-x]  corretto-11
│   │   └── [drwxr-xr-x]  corretto-17
│   ├── [drwxrwxrwx]  .m2
│   │   └── [drwxrwxrwx]  repository
│   └── [-rwxrwxrwx]  .profile
```

So this PR fixes exactly that issue.