### PR TITLE
CPP-43482: Disable ctest plugin in qodana-cpp

### DIFF
--- a/2025.1/cpp/disabled_plugins.txt
+++ b/2025.1/cpp/disabled_plugins.txt
@@ -1,1 +1,2 @@
 com.jetbrains.codeWithMe
+org.jetbrains.plugins.clion.ctest

--- a/2025.1/cpp/disabled_plugins.txt
+++ b/2025.1/cpp/disabled_plugins.txt
@@ -1,2 +1,1 @@
 com.jetbrains.codeWithMe
-org.jetbrains.plugins.clion.ctest

--- a/2025.1/cpp/included_plugins.txt
+++ b/2025.1/cpp/included_plugins.txt
@@ -32,7 +32,6 @@ com.intellij.dts
 com.intellij.clion-makefile
 com.jetbrains.clion.plugins.webDeployment
 org.jetbrains.plugins.clion.test.google
-org.jetbrains.plugins.clion.ctest
 org.jetbrains.plugins.clion.test.catch
 org.jetbrains.plugins.clion.test.boost
 com.intellij.clion.rd.components


### PR DESCRIPTION
The issue mentioned in MR title reproduces often on `qodana-cpp`. Dmitry Kozhevnikov suggested:

> As a simple workaround which should make the issue go away but won't fix the underlying issue - you can disable org.jetbrains.plugins.clion.ctest plugin (it's worth doing anyway, you don't need it on Qodana run).

P.S. Please let me know if I should have added the plugin to `disabled_plugins` or removed it from `included_plugins`. I am not sure what the difference is.