### PR TITLE
QD-8148 push w/o checkout ref, exit w/o error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,11 @@ on:
       - main
     paths:
       - '**/Dockerfile'
+      - '**/Dockerfile.j2'
   pull_request:
     paths:
       - '**/Dockerfile'
+      - '**/Dockerfile.j2'
   schedule:
     - cron: '0 0 * * 1'
 
@@ -38,11 +40,9 @@ jobs:
               git diff --ignore-space-at-eol HEAD -- ${{ matrix.release }}
               git config user.name github-actions
               git config user.email github-actions@github.com
-              git checkout $GITHUB_REF
               git add .
               git commit -m "QD-8148 Update \`${{ matrix.release }}\` Dockerfiles"
               git push
-              exit 1
           fi
         if: steps.changes.outputs.dockerfiles == 'true'
 


### PR DESCRIPTION
# Pull Request Details

## Description

Removed ref checkout to prevent deattached head and exit 1. Added templates change to triggers.

## Motivation and Context

Now, you should generated new docker files with the script before push, otherwise you will get deattached stated during ci workflow and pushing of diff changes will fail(see recent action with diff results). I'm not sure if it was intended, but suggest always push generated docker files in the ci workflow, even if there were manual changes in this docker files before. And since checkout v2 action version, you  don't have to to checkout to prevent deattached head(moreover, it will now lead to it).  And we do not need fail workflow in this case, because it is expected behaviour.