### PR TITLE
QD-8148 move docker generation to a separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,46 +6,13 @@ on:
       - main
     paths:
       - '**/Dockerfile'
-      - '**/Dockerfile.j2'
   pull_request:
     paths:
       - '**/Dockerfile'
-      - '**/Dockerfile.j2'
   schedule:
     - cron: '0 0 * * 1'
 
 jobs:
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        release: [ "2025.1" ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            dockerfiles:
-              - '${{ matrix.release }}/**'
-      - if: steps.changes.outputs.dockerfiles == 'true'
-        run: ./dockerfiles.py ${{ matrix.release }}
-      - name: Compare the expected and actual directories
-        run: |
-          git status
-          if [ "$(git status --porcelain ${{ matrix.release }} | wc -l)" -gt "0" ]; then
-              echo "Detected uncommitted changes after build. See status below:"
-              git diff --ignore-space-at-eol HEAD -- ${{ matrix.release }}
-              git config user.name github-actions
-              git config user.email github-actions@github.com
-              git add .
-              git commit -m "QD-8148 Update \`${{ matrix.release }}\` Dockerfiles"
-              git push
-          fi
-        if: steps.changes.outputs.dockerfiles == 'true'
-
   build243:
     name: "2024.3"
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: 'Lint'
+on:
+  pull_request:
+    paths:
+      - '**/Dockerfile'
+      - '**/Dockerfile.j2'
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release: [ "2025.1" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            dockerfiles:
+              - '${{ matrix.release }}/**'
+      - if: steps.changes.outputs.dockerfiles == 'true'
+        run: ./dockerfiles.py ${{ matrix.release }}
+      - name: Compare the expected and actual directories
+        run: |
+          git status
+          if [ "$(git status --porcelain ${{ matrix.release }} | wc -l)" -gt "0" ]; then
+              echo "Detected uncommitted changes after build. See status below:"
+              git diff --ignore-space-at-eol HEAD -- ${{ matrix.release }}
+              git config user.name github-actions
+              git config user.email github-actions@github.com
+              git add .
+              git commit -m "QD-8148 Update \`${{ matrix.release }}\` Dockerfiles"
+              git push
+          fi
+        if: steps.changes.outputs.dockerfiles == 'true'


### PR DESCRIPTION
# Pull Request Details
I didn't take into account that we have a protected master and now when generating a docker there is an error when pushing new files. What I did: I moved the generation to a separate workflow, which only works on a pull request in the branch. I added a with option to the checkout so that it would checkout without head deattachment.