### PR TITLE
QD-13869 Fix stale plugin IDs in C++ included_plugins.txt

### DIFF
--- a/2025.2/cpp/included_plugins.txt
+++ b/2025.2/cpp/included_plugins.txt
@@ -20,7 +20,7 @@ name.kropp.intellij.makefile
 Remote Development Server
 org.intellij.intelliLang
 Docker
-com.intellij.cidr.base
+com.intellij.cidr.lang
 com.intellij.cidr.lang.clangd
 com.intellij.clion.west
 com.intellij.clion
@@ -65,7 +65,6 @@ JSIntentionPowerPack
 com.jetbrains.linkerscript
 org.jetbrains.plugins.clangConfig
 org.jetbrains.plugins.clangFormat
-intellij.rider.cpp.debugger
 AngularJS
 com.jetbrains.codeWithMe
 com.intellij.modules.python

--- a/2025.3/cpp/included_plugins.txt
+++ b/2025.3/cpp/included_plugins.txt
@@ -19,7 +19,7 @@ org.jetbrains.plugins.terminal
 name.kropp.intellij.makefile
 org.intellij.intelliLang
 Docker
-com.intellij.cidr.base
+com.intellij.cidr.lang
 com.intellij.cidr.lang.clangd
 com.intellij.clion.west
 com.intellij.clion
@@ -58,7 +58,6 @@ intellij.nextjs
 Karma
 JSIntentionPowerPack
 com.jetbrains.linkerscript
-intellij.rider.cpp.debugger
 AngularJS
 com.jetbrains.codeWithMe
 com.intellij.modules.python

--- a/next/cpp/included_plugins.txt
+++ b/next/cpp/included_plugins.txt
@@ -19,7 +19,7 @@ org.jetbrains.plugins.terminal
 name.kropp.intellij.makefile
 org.intellij.intelliLang
 Docker
-com.intellij.cidr.base
+com.intellij.cidr.lang
 com.intellij.cidr.lang.clangd
 com.intellij.clion.west
 com.intellij.clion
@@ -58,7 +58,6 @@ intellij.nextjs
 Karma
 JSIntentionPowerPack
 com.jetbrains.linkerscript
-intellij.rider.cpp.debugger
 AngularJS
 com.jetbrains.codeWithMe
 com.intellij.modules.python


### PR DESCRIPTION
## Summary
- Replace `com.intellij.cidr.base` with `com.intellij.cidr.lang` (plugin was renamed)
- Remove `intellij.rider.cpp.debugger` (was never a valid top-level plugin ID; debugger is included transitively via `com.intellij.clion`)

Updated in `next/`, `2025.3/`, and `2025.2/` directories.

These stale IDs cause `QodanaExcludedPluginsCalculator` to exclude critical C++ analysis plugins from the Docker image, resulting in the nightly smoke test failing with exit code 0 instead of 255.

## Test plan
- Re-trigger the nightly CPP build on TeamCity
- Verify `com.intellij.cidr.lang` resolves without "Can't find plugin descriptor" errors
- Verify smoke test exits with code 255 (C++ problems found)